### PR TITLE
Add Ada implementation

### DIFF
--- a/fib.adb
+++ b/fib.adb
@@ -1,0 +1,28 @@
+with Ada.Text_IO;
+
+procedure Fib is
+   procedure Print(Item : Natural) is
+      S : constant String := Natural'Image(Item);
+   begin
+      -- remove the leading space (reserved for the sign); Natural guarantees
+      -- that the number can never be negative, so we can safely take the
+      -- substring whithout checking for the first character
+      Ada.Text_IO.Put_Line(S(S'First + 1 .. S'Last));
+   end Print;
+
+   A, B : Natural;
+begin
+   Print(0);
+   Print(1);
+   A := 1;
+   Print(A);
+   B := A + A;
+   Print(B);
+   while A < 1000000 loop
+      A := A + B;
+      Print(A);
+      B := A + B;
+      Print(B);
+   end loop;
+end Fib;
+


### PR DESCRIPTION
This adds an implementation in the [**Ada** programming language.](https://en.wikipedia.org/wiki/Ada_%28programming_language%29) Please note, it's actually been several years that I've coded Ada, but people agreed on indenting Ada code with three (!) spaces for whatever reason. Here's the [tutorial](https://en.wikibooks.org/wiki/Ada_Programming/Basic).

The language is incredibly type safe and thus the perfect choice to build highly critical real time systems. Not only does it power several railway transport systems, it also runs in air- and spacecrafts. How cool is that!?


If one's okay with a leading space in front of each number, simply drop the `Print` helper function and use `Ada.Text_IO.Put_Line(A'Image);` instead. The first two `Print(…)` calls can be changed accordingly with string literals, such as `Ada.Text_IO.Put_Line("0");`. Alternatively one could also use `Ada.Integer_Text_IO.Put(A); Ada.Text_IO.New_Line;`, which would right-align the numbers.

On Debian Testing install the `gnat-10` (GNU Ada compiler) package and compile the code using:
```
gnatmake fib.adb
```

Run it with:
```
./fib
```