### PR TITLE
Zig example didn't work

### DIFF
--- a/fib.zig
+++ b/fib.zig
@@ -1,21 +1,18 @@
-const warn = std.debug.warn;
 const std = @import("std");
-const os = std.os;
-const assert = std.debug.assert;
 
-pub fn main() void {
-    const zero: i32 = 0;
-    warn("{}\n", zero);
-    const one: i32 = 1;
-    warn("{}\n", one);
-    var a: i32 = 1;
-    warn("{}\n", a);
-    var b: i32 = a + a;
-    warn("{}\n", b);
-    while (a < 1000000){
-        a = a + b;
-        warn("{}\n", a);
-        b = a + b;
-        warn("{}\n", b);
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+
+    var a: u32 = 1;
+    try stdout.print("{}\n{}\n", .{ a, a });
+
+    var b: u32 = 2 * a;
+    try stdout.print("{}\n", .{b});
+
+    while (a < 1000000) {
+        a += b;
+        try stdout.print("{}\n", .{a});
+        b += a;
+        try stdout.print("{}\n", .{b});
     }
 }

--- a/fib.zig
+++ b/fib.zig
@@ -2,9 +2,11 @@ const std = @import("std");
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
-
+    
+    try stdout.print("0\n1\n", .{});
+    
     var a: u32 = 1;
-    try stdout.print("{}\n{}\n", .{ a, a });
+    try stdout.print("{}\n{}\n", .{a});
 
     var b: u32 = 2 * a;
     try stdout.print("{}\n", .{b});

--- a/fib.zig
+++ b/fib.zig
@@ -6,7 +6,7 @@ pub fn main() !void {
     try stdout.print("0\n1\n", .{});
     
     var a: u32 = 1;
-    try stdout.print("{}\n{}\n", .{a});
+    try stdout.print("{}\n", .{a});
 
     var b: u32 = 2 * a;
     try stdout.print("{}\n", .{b});


### PR DESCRIPTION
zig is my favorite langage but that was a bit ugly haha
plus `warn("{}\n", var);` doesn't work, it needs a tuple: `warn("{}\n", .{var});`